### PR TITLE
fix: feature/384 fix share, bookmark, like shown when not login

### DIFF
--- a/client/src/components/farmProfileConsumer/productCard/productCard.jsx
+++ b/client/src/components/farmProfileConsumer/productCard/productCard.jsx
@@ -7,8 +7,12 @@ import {
     Label,
 } from './productCard.styles'
 import { Link } from 'react-router-dom'
+import { useContext} from 'react'
+import { UserContext } from '../../../context/userContext/userContext'
 
 const ProductCard = ({ width, height, product, farmID }) => {
+    const { user } = useContext(UserContext)
+
     return (
         <Container width={width} height={height}>
             <div id="imageContainer">
@@ -28,9 +32,12 @@ const ProductCard = ({ width, height, product, farmID }) => {
                         />
                     </Link>
                 </div>
-                <div>
-                    <CircleButton IconName="FavoriteEmpty" />
-                </div>
+                {user.id && (
+                    <div>
+                        <CircleButton IconName="FavoriteEmpty" />
+                    </div>
+                )}
+
             </div>
             <DetailsContainer>
                 <DetailsContainerChild gridColumn="1/2" gridRow="1/2">

--- a/client/src/components/marketDirectoryComponents/productCard/productCard.styles.js
+++ b/client/src/components/marketDirectoryComponents/productCard/productCard.styles.js
@@ -17,9 +17,10 @@ export const CardContainer = styled.div`
             padding: 0.2rem 0.3rem;
             border-radius: 50%;
             position: absolute;
-            top: 0;
+            top: 0.5rem;
             right: 0.5rem;
             cursor: pointer;
+            background-color: #ffffff;
         }
     }
 

--- a/client/src/components/marketDirectoryComponents/productCardDirectory/productCardDirectory.styles.js
+++ b/client/src/components/marketDirectoryComponents/productCardDirectory/productCardDirectory.styles.js
@@ -27,11 +27,13 @@ export const Container = styled.div`
             justify-content: space-between;
             width: 100%;
 
-            & .bookmark-container {
+            & .bookmark-container svg {
                 border: 1px solid ${theme.pallette.black[200]};
                 border-radius: 50%;
                 padding: 0.2rem 0.33rem;
                 cursor: pointer;
+                align-items: flex-start;
+                font-size: 2.5rem;
             }
         }
 
@@ -112,11 +114,13 @@ export const Container = styled.div`
                 width: 100%;
                 padding-right: 0.7rem;
 
-                & .bookmark-container {
+                & .bookmark-container svg {
                     border: 1px solid ${theme.pallette.black[200]};
                     border-radius: 50%;
                     padding: 0.2rem 0.33rem;
                     cursor: pointer;
+                    align-items: flex-start;
+                    font-size: 2.5rem;
                 }
             }
         }

--- a/client/src/components/productDetailConsumer/header/productDetailHeader.jsx
+++ b/client/src/components/productDetailConsumer/header/productDetailHeader.jsx
@@ -87,20 +87,22 @@ const ProductDetailHeader = ({
                         <h5>{altitude}</h5>
                     </div>
                 </div>
-                <div id="buttons">
-                    <ButtonShare
-                        borderColor={theme.pallette.black[500]}
-                        textColor={theme.pallette.black[900]}
-                        onClick={handleShare}
-                    ></ButtonShare>
-                    <ButtonHeart
-                        onClick={handleLike}
-                        liked={liked}
-                        onMouseEnter = {event => handleOnMouseEnter(event)}
-                        onMouseLeave = {event => handleOnMouseLeave(event)}
-                        hover={hover}
-                    ></ButtonHeart>
-                </div>
+                {user.id && (
+                    <div id="buttons">
+                        <ButtonShare
+                            borderColor={theme.pallette.black[500]}
+                            textColor={theme.pallette.black[900]}
+                            onClick={handleShare}
+                        ></ButtonShare>
+                        <ButtonHeart
+                            onClick={handleLike}
+                            liked={liked}
+                            onMouseEnter = {event => handleOnMouseEnter(event)}
+                            onMouseLeave = {event => handleOnMouseLeave(event)}
+                            hover={hover}
+                        ></ButtonHeart>
+                    </div>
+                )}
             </HeaderMainContainer>
         </HeaderContainer>
     )

--- a/client/src/components/productDetailConsumer/productCard/productCard.jsx
+++ b/client/src/components/productDetailConsumer/productCard/productCard.jsx
@@ -7,8 +7,12 @@ import {
     Label,
 } from './productCard.styles'
 import { Link } from 'react-router-dom'
+import { useContext} from 'react'
+import { UserContext } from '../../../context/userContext/userContext'
 
 const ProductCard = ({ width, height, product, farmID }) => {
+    const { user } = useContext(UserContext)
+
     return (
         <Container width={width} height={height}>
             <div id="imageContainer">
@@ -28,9 +32,11 @@ const ProductCard = ({ width, height, product, farmID }) => {
                         />
                     </Link>
                 </div>
-                <div>
-                    <CircleButton IconName="FavoriteEmpty" />
-                </div>
+                {user.id && (
+                    <div>
+                        <CircleButton IconName="FavoriteEmpty" />
+                    </div>
+                )}
             </div>
             <DetailsContainer>
                 <DetailsContainerChild gridColumn="1/2" gridRow="1/2">


### PR DESCRIPTION
Hi Sam!

I am sorry, I did not see your card in sprint log and included that part here. 
In case you already did it and better use yours, please let me know. 

In this PR, I did the following, please check. (#384)
- In product detail page, share and like button at the top were shown when I am not login >> Removed 
- In product detail page and farm profile page, other product cards at the bottom had like mark when I am not login >> Removed
- Bookmark in Farm Directory was vertically growing when the farm name became 2 rows >> Fixed
- Like mark in Marketplace was on edge and no background colour while mockup's background is white >> put white for background and lowered the position a bit.    

Thank you