### PR TITLE
fix feature/388 Remove line on top of carousel

### DIFF
--- a/client/src/components/productDetailConsumer/imagesGroup/productDetailImagesCarousel.jsx
+++ b/client/src/components/productDetailConsumer/imagesGroup/productDetailImagesCarousel.jsx
@@ -55,52 +55,29 @@ const ProductDetailImagesCarousel = ({
     return (
         <div>
             <CarouselContainer>
-                <Carousel
-                    fade
-                    // className="h-100"
-                    variant="dark"
-                    activeIndex={index}
-                    onSelect={handleSelect}
-                    nextLabel={''}
-                    prevLabel={''}
-                    id="divCarousel"
-                >
-                    <Carousel.Item>
-                        <img
-                            className="d-block w-100 h-100"
-                            src={urlsArray[0]}
-                            alt=""
-                        />
-                    </Carousel.Item>
-                    <Carousel.Item>
-                        <img
-                            className="d-block w-100 h-100"
-                            src={urlsArray[1]}
-                            alt=""
-                        />
-                    </Carousel.Item>
-                    <Carousel.Item>
-                        <img
-                            className="d-block w-100 h-100"
-                            src={urlsArray[2]}
-                            alt=""
-                        />
-                    </Carousel.Item>
-                    <Carousel.Item>
-                        <img
-                            className="d-block w-100 h-100"
-                            src={urlsArray[3]}
-                            alt=""
-                        />
-                    </Carousel.Item>
-                    <Carousel.Item>
-                        <img
-                            className="d-block w-100 h-100"
-                            src={urlsArray[4]}
-                            alt=""
-                        />
-                    </Carousel.Item>
-                </Carousel>
+                {urlsArray.length === 1 ? <img src={urlsArray[0]} alt="" width="100%"/> :
+                    <Carousel
+                        fade
+                        // className="h-100"
+                        variant="dark"
+                        activeIndex={index}
+                        onSelect={handleSelect}
+                        nextLabel={''}
+                        prevLabel={''}
+                        id="divCarousel"
+                        indicators={false}
+                    >
+                        {urlsArray.map(url=>
+                            (<Carousel.Item key={url}>
+                                <img
+                                    className="d-block w-100 h-100"
+                                    src={url}
+                                    alt=""
+                                />
+                            </Carousel.Item>)
+                        )}
+                    </Carousel>
+                }
                 <div id="divCircleButtons">
                     <CircleButton
                         IconName={liked ? 'FavoriteFull' : 'FavoriteEmpty'}


### PR DESCRIPTION
Hi All,

- Removed the lines (indicators) on top of carousel in mobile view of product detail page. (#388)
- Also it was showing all white when there was no image added, but moving to the next by clicking ">" icon >> Changed to display available images instead of fixed 5. And also if there is only 1 image, then shows just <img> instead of carousel (thought it's not nice to have "<" ">" if only 1 image available)
- For the colour of ">", I kept dark although mockup is white, since our sample has white background and cannot see at all in that case

Please check and let me know if any issue. 
Thank you.