### PR TITLE
fix feature/391 Fix typo origin1 in product detail page

### DIFF
--- a/client/src/components/productDetailConsumer/header/productDetailHeader.jsx
+++ b/client/src/components/productDetailConsumer/header/productDetailHeader.jsx
@@ -75,7 +75,7 @@ const ProductDetailHeader = ({
                 <div id="origin">
                     <div>
                         <div>
-                            <p>Origin1:</p>
+                            <p>Origin:</p>
                             <h5>{origin}</h5>
                         </div>
                         <div>


### PR DESCRIPTION
Hi All,

Just fixed the typo "Origin1" >> "Origin" in product detail page (#391)
Thank you