### PR TITLE
fix: feature/393 Remove background in small menu at the top

### DIFF
--- a/client/src/components/loggedUser/loggedUser.styles.js
+++ b/client/src/components/loggedUser/loggedUser.styles.js
@@ -53,6 +53,15 @@ export const Container = styled.div`
             margin-top: 20px;
         }
 
+        .dropdown-item {
+            color: ${theme.pallette.black[900]}
+        }
+
+        .dropdown-item:hover, .dropdown-item:active {
+            background: none;
+            font-weight: bold;
+        }
+
         #sign-out {
             color: red;
         }


### PR DESCRIPTION
Hi All,

In the small menu on top right when logged in, there was grey background on hover and blue background on active
 - removed background and made it bold on hover and on active

Kindly check. Thank you.  